### PR TITLE
Wallet screen

### DIFF
--- a/lib/features/authenticated/authenticated_screen.dart
+++ b/lib/features/authenticated/authenticated_screen.dart
@@ -47,22 +47,6 @@ class _AuthenticatedScreenState extends State<AuthenticatedScreen> {
     );
   }
 
-  // Handle back navigation with logout
-  Future<void> _handleBackNavigation() async {
-    try {
-      await _privyManager.privy.logout();
-
-      if (mounted) {
-        // Navigate back to home after logout
-        context.go('/');
-      }
-    } catch (e) {
-      if (mounted) {
-        _showMessage("Logout error: $e", isError: true);
-      }
-    }
-  }
-
   // Create Ethereum wallet
   Future<void> _createEthereumWallet() async {
 
@@ -154,10 +138,6 @@ class _AuthenticatedScreenState extends State<AuthenticatedScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Profile'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: _handleBackNavigation,
-        ),
       ),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/lib/features/authenticated/authenticated_screen.dart
+++ b/lib/features/authenticated/authenticated_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_starter/core/privy_manager.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privy_flutter/privy_flutter.dart';
 
-import 'package:flutter_starter/router/app_router.dart';
 import 'package:flutter_starter/features/authenticated/widgets/ethereum_wallets_widget.dart';
 import 'package:flutter_starter/features/authenticated/widgets/linked_accounts_widget.dart';
 import 'package:flutter_starter/features/authenticated/widgets/solana_wallets_widget.dart';
@@ -155,19 +154,13 @@ class _AuthenticatedScreenState extends State<AuthenticatedScreen> {
 
               const SizedBox(height: 16),
 
-              // Ethereum Wallets
-              GestureDetector(
-                onTap: () => context.go(AppRouter.walletPath),
-                child: EthereumWalletsWidget(user: _user),
-              ),
+              // Ethereum Wallets (Navigation handled inside widget)
+              EthereumWalletsWidget(user: _user),
 
               const SizedBox(height: 24),
 
-              // Solana Wallets
-              GestureDetector(
-                onTap: () => context.go(AppRouter.walletPath),
-                child: SolanaWalletsWidget(user: _user),
-              ),
+              // Solana Wallets (Navigation handled inside widget)
+              SolanaWalletsWidget(user: _user),
             ],
           ),
         ),

--- a/lib/features/authenticated/widgets/ethereum_wallets_widget.dart
+++ b/lib/features/authenticated/widgets/ethereum_wallets_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_starter/router/app_router.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privy_flutter/privy_flutter.dart';
 
 /// Widget that displays all Ethereum wallets for a Privy user
@@ -28,49 +30,59 @@ class EthereumWalletsWidget extends StatelessWidget {
   }
 
   Widget _buildWalletTile(BuildContext context, EmbeddedEthereumWallet wallet) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.account_balance_wallet),
-                const SizedBox(width: 8),
+    // Wrap in InkWell for navigation
+    return InkWell(
+      onTap: () {
+        // Navigate using named route and pass wallet object via 'extra'
+        context.goNamed(
+          AppRouter.walletRoute,
+          extra: wallet, // Pass the wallet object
+        );
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.account_balance_wallet),
+                  const SizedBox(width: 8),
+                  Text(
+                    "Ethereum Wallet",
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                "Address: ${_formatAddress(wallet.address)}",
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              if (wallet.chainId != null)
                 Text(
-                  "Ethereum Wallet",
-                  style: Theme.of(context).textTheme.titleMedium,
+                  "Chain ID: ${wallet.chainId}",
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(color: Colors.grey),
                 ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              "Address: ${_formatAddress(wallet.address)}",
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            if (wallet.chainId != null)
+              if (wallet.recoveryMethod != null)
+                Text(
+                  "Recovery Method: ${wallet.recoveryMethod}",
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(color: Colors.grey),
+                ),
               Text(
-                "Chain ID: ${wallet.chainId}",
+                "HD Wallet Index: ${wallet.hdWalletIndex}",
                 style: Theme.of(
                   context,
                 ).textTheme.bodySmall?.copyWith(color: Colors.grey),
               ),
-            if (wallet.recoveryMethod != null)
-              Text(
-                "Recovery Method: ${wallet.recoveryMethod}",
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(color: Colors.grey),
-              ),
-            Text(
-              "HD Wallet Index: ${wallet.hdWalletIndex}",
-              style: Theme.of(
-                context,
-              ).textTheme.bodySmall?.copyWith(color: Colors.grey),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/authenticated/widgets/solana_wallets_widget.dart
+++ b/lib/features/authenticated/widgets/solana_wallets_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_starter/router/app_router.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privy_flutter/privy_flutter.dart';
 
 /// Widget that displays all Solana wallets for a Privy user
@@ -25,43 +27,53 @@ class SolanaWalletsWidget extends StatelessWidget {
   }
 
   Widget _buildWalletTile(BuildContext context, EmbeddedSolanaWallet wallet) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.account_balance_wallet),
-                const SizedBox(width: 8),
+    // Wrap in InkWell for navigation
+    return InkWell(
+      onTap: () {
+        // Navigate using named route and pass wallet object via 'extra'
+        context.goNamed(
+          AppRouter.walletRoute,
+          extra: wallet, // Pass the wallet object
+        );
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.account_balance_wallet),
+                  const SizedBox(width: 8),
+                  Text(
+                    "Solana Wallet",
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                "Address: ${_formatAddress(wallet.address)}",
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              if (wallet.chainId != null)
                 Text(
-                  "Solana Wallet",
-                  style: Theme.of(context).textTheme.titleMedium,
+                  "Chain ID: ${wallet.chainId}",
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
                 ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              "Address: ${_formatAddress(wallet.address)}",
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            if (wallet.chainId != null)
+              if (wallet.recoveryMethod != null)
+                Text(
+                  "Recovery Method: ${wallet.recoveryMethod}",
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
+                ),
               Text(
-                "Chain ID: ${wallet.chainId}",
+                "HD Wallet Index: ${wallet.hdWalletIndex}",
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
               ),
-            if (wallet.recoveryMethod != null)
-              Text(
-                "Recovery Method: ${wallet.recoveryMethod}",
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
-              ),
-            Text(
-              "HD Wallet Index: ${wallet.hdWalletIndex}",
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/email_authentication/email_authentication_screen.dart
+++ b/lib/features/email_authentication/email_authentication_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_starter/core/privy_manager.dart';
+import 'package:flutter_starter/router/app_router.dart';
 import 'package:go_router/go_router.dart';
 
 
@@ -120,11 +121,10 @@ class EmailAuthenticationScreenState extends State<EmailAuthenticationScreen> {
           });
           showMessage("Authentication successful!");
 
-          // Navigate to authenticated screen(un needed if using auth state dependant routing)
-          // The authenticatedPath constant is defined in app_router.dart
-          // if (mounted) {
-          //   context.go(AppRouter.authenticatedPath);
-          // }
+          // Navigate to authenticated screen
+          if (mounted) {
+            context.go(AppRouter.authenticatedPath);
+          }
         },
         // Failure handler - authentication failed
         onFailure: (error) {

--- a/lib/features/wallet/wallet_screen.dart
+++ b/lib/features/wallet/wallet_screen.dart
@@ -1,21 +1,113 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privy_flutter/privy_flutter.dart';
 
 class WalletScreen extends StatelessWidget {
-  const WalletScreen({super.key});
+  final EmbeddedEthereumWallet? ethereumWallet;
+  final EmbeddedSolanaWallet? solanaWallet;
+
+  const WalletScreen({
+    super.key,
+    this.ethereumWallet,
+    this.solanaWallet,
+  }); 
 
   @override
   Widget build(BuildContext context) {
+    // Determine wallet type and details from constructor arguments
+    final bool isEthereum = ethereumWallet != null;
+    final walletDetails = isEthereum ? ethereumWallet! : solanaWallet!;
+    final String walletType = isEthereum ? 'Ethereum' : 'Solana';
+    final String address = walletDetails.address;
+    final String? recoveryMethod = walletDetails.recoveryMethod;
+    final int hdWalletIndex = walletDetails.hdWalletIndex;
+    final String? chainId = walletDetails.chainId;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('My wallet'),
+        title: Text('$walletType Wallet Details'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/profile'),
+          // Use canPop to avoid issues if this is the first screen
+          onPressed: () => context.canPop() ? context.pop() : context.go('/profile'), 
         ),
       ),
-      body: const Center(
-        child: Text('My wallet', style: TextStyle(fontSize: 24)),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.account_balance_wallet, size: 28), 
+                    const SizedBox(width: 12),
+                    Text(
+                      '$walletType Wallet',
+                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Divider(),
+                const SizedBox(height: 20),
+                
+                _buildDetailItem(context, 'Address', address),
+                
+                // Display chainId if available
+                if (chainId != null && chainId.isNotEmpty)
+                  _buildDetailItem(context, 'Chain ID', chainId),
+                
+                if (recoveryMethod != null && recoveryMethod.isNotEmpty)
+                    _buildDetailItem(context, 'Recovery Method', recoveryMethod),
+                
+                // Always show HD index as it's non-nullable
+                _buildDetailItem(context, 'HD Wallet Index', hdWalletIndex.toString()),
+                
+                const SizedBox(height: 24),
+                Center(
+                  child: OutlinedButton.icon(
+                    icon: Icon(Icons.copy),
+                    label: const Text('Copy Address'),
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: address));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Address copied to clipboard!')), 
+                      );
+                    },
+                    style: OutlinedButton.styleFrom(
+                      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDetailItem(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600, color: Colors.grey[700]),
+          ),
+          const SizedBox(height: 4),
+          SelectableText(
+            value, 
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+        ],
       ),
     );
   }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+// import 'package:flutter_starter/core/privy_manager.dart'; // Removed unused import
 import 'package:flutter_starter/features/authenticated/authenticated_screen.dart';
 import 'package:flutter_starter/features/email_authentication/email_authentication_screen.dart';
 import 'package:flutter_starter/features/home/home_screen.dart';
 import 'package:flutter_starter/features/wallet/wallet_screen.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privy_flutter/privy_flutter.dart';
 
 class AppRouter {
   // Private constructor to prevent direct instantiation
@@ -46,7 +48,24 @@ class AppRouter {
       GoRoute(
         path: walletPath,
         name: walletRoute,
-        builder: (context, state) => const WalletScreen(),
+        builder: (context, state) {
+          // Extract the wallet object from the 'extra' parameter
+          final wallet = state.extra;
+
+          if (wallet is EmbeddedEthereumWallet) {
+            return WalletScreen(ethereumWallet: wallet); 
+          } else if (wallet is EmbeddedSolanaWallet) {
+            return WalletScreen(solanaWallet: wallet); 
+          } else {
+            // Handle error: Invalid or missing wallet object
+            return Scaffold(
+              appBar: AppBar(title: const Text('Error')),
+              body: const Center(
+                child: Text('Invalid wallet data provided.'),
+              ),
+            );
+          }
+        },
       ),
       GoRoute(
         path: emailAuthPath,


### PR DESCRIPTION
[Wallet_screen_demo.webm](https://github.com/user-attachments/assets/08f52c82-5093-4f67-a16c-c193f1aa3079)

Pass wallet as nullable solana wallet or eth wallet through the route

Add routing to wallet screen and pass selevted wallet through the route.

Remove gesture detectors wrapping the Wallet Widgets themselves

Add display info for selected wallet on wallet_screen.
